### PR TITLE
Change settings to that work with the t-mobile network

### DIFF
--- a/src/Sodaq_nbIOT.cpp
+++ b/src/Sodaq_nbIOT.cpp
@@ -84,9 +84,9 @@ typedef struct NameValuePair {
 
 const uint8_t nConfigCount = 6;
 static NameValuePair nConfig[nConfigCount] = {
-    { "AUTOCONNECT", false },
+    { "AUTOCONNECT", true },
     { "CR_0354_0338_SCRAMBLING", true },
-    { "CR_0859_SI_AVOID", false },
+    { "CR_0859_SI_AVOID", true },
     { "COMBINE_ATTACH", false },
     { "CELL_RESELECTION", false },
     { "ENABLE_BIP", false },


### PR DESCRIPTION
Changed settings to what's said in this guide:
https://forum.iot.t-mobile.nl/topic/229/manual-part-1-network-attach
This should make this library compatible with the t-mobile network again.
The module connects with these settings in my setup, and not with the settings that were there before.